### PR TITLE
修复听筒感应功能在部分手机上无法还原正常模式的问题

### DIFF
--- a/src/org/zywx/wbpalmstar/plugin/uexaudio/PFMusicPlayer.java
+++ b/src/org/zywx/wbpalmstar/plugin/uexaudio/PFMusicPlayer.java
@@ -20,6 +20,7 @@ import android.media.MediaPlayer.OnErrorListener;
 import android.media.SoundPool;
 import android.net.Uri;
 import android.os.Environment;
+import android.util.Log;
 import android.widget.Toast;
 
 public abstract class PFMusicPlayer {
@@ -380,10 +381,8 @@ public abstract class PFMusicPlayer {
 		}
 	}
 	
-	public void checkModeEnd(){
-		if(isModeInCall){
-			playModeNormol();
-		}
+	public void checkModeEnd() {
+		playModeNormol();
 	}
 	
 	/**
@@ -418,29 +417,35 @@ public abstract class PFMusicPlayer {
 			
 			@Override
 			public void onSensorChanged(SensorEvent event) {
-				float range = event.values[0];
-				SensorManager mSensorManager = (SensorManager) m_context.getApplicationContext().getSystemService(Context.SENSOR_SERVICE);
-				Sensor mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
-				if (range == mSensor.getMaximumRange()) {
-					if(m_mediaPlayer != null){
-						if(isModeInCall){
-							return;
-						}else if(m_mediaPlayer.isPlaying()){
-							m_mediaPlayer.pause();
-							playModeNormol();
-							m_mediaPlayer.start();
+				try {
+					float range = event.values[0];
+					SensorManager mSensorManager = (SensorManager) m_context.getApplicationContext().getSystemService(Context.SENSOR_SERVICE);
+					Sensor mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
+					Log.i("uexAudio_onSensorChanged",range + "   max:" + mSensor.getMaximumRange());
+					if (range == 0) {
+						if(m_mediaPlayer != null){
+							if(isModeInCall){
+								return;
+							}
+							if(m_mediaPlayer.isPlaying()){
+								m_mediaPlayer.pause();
+								playModeInCall();
+								m_mediaPlayer.start();
+							}
+						}
+					} else {
+						if(m_mediaPlayer != null){
+							if(isModeInCall){
+								return;
+							}
+							if(m_mediaPlayer.isPlaying()){
+								m_mediaPlayer.pause();
+								playModeNormol();
+								m_mediaPlayer.start();
+							}
 						}
 					}
-				} else {
-					if(m_mediaPlayer != null){
-						if(isModeInCall){
-							return;
-						}else if(m_mediaPlayer.isPlaying()){
-							m_mediaPlayer.pause();
-							playModeInCall();
-							m_mediaPlayer.start();
-						}
-					}
+				} catch (Exception e) {
 				}
 			}
 			

--- a/uexAudio/info.xml
+++ b/uexAudio/info.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <uexplugins>
     <plugin
-        uexName="uexAudio" version="3.0.8" build="8">
-        <info>8:添加传感器设置接口,可设置听筒感应</info>
+        uexName="uexAudio" version="3.0.9" build="9">
+        <info>9:修复听筒感应功能在部分手机上无法还原正常模式的问题</info>
+        <build>8:添加传感器设置接口,可设置听筒感应</build>
         <build>7:解决了录音时用户禁止其权限的问题</build>
         <build>6:添加听筒模式接口,修复小米手机音量设置无效的问题</build>
         <build>5:修复uexAudio.record方法不支持录音文件存储为.mp3格式的问题</build>


### PR DESCRIPTION
由于部分手机听筒距离感应器的距离最大值并不统一，甚至部分手机存在实际值与最大值不一致的问题。导致开启听筒感应后无法正确还原正常播放模式的问题。已修正相关逻辑。
